### PR TITLE
Align sql.js version in worker

### DIFF
--- a/README.md
+++ b/README.md
@@ -122,3 +122,9 @@ output to `/out`. To build the project:
 ```bash
 bun run build
 ```
+
+### sql.js version
+
+The data worker loads `sql.js` from a CDN. Ensure that the version referenced
+in `public/workers/data-worker.ts` matches the `sql.js` dependency in
+`package.json` so the worker can locate the correct files.

--- a/public/workers/data-worker.ts
+++ b/public/workers/data-worker.ts
@@ -10,6 +10,11 @@ declare var self: Worker;
 let db: Dexie;
 let table: Table;
 let sql: initSqlJs.SqlJsStatic;
+/**
+ * sql.js is loaded from the CDN. Keep this version in sync with the
+ * dependency declared in package.json to avoid mismatches.
+ */
+const SQL_JS_VERSION = "1.13.0";
 
 async function init() {
   if (!db) {
@@ -20,7 +25,7 @@ async function init() {
     table = db.table("db");
     sql = await initSqlJs({
       locateFile: (file) =>
-        `https://cdnjs.cloudflare.com/ajax/libs/sql.js/1.11.0/${file}`,
+        `https://cdnjs.cloudflare.com/ajax/libs/sql.js/${SQL_JS_VERSION}/${file}`,
     });
   }
 }


### PR DESCRIPTION
## Summary
- keep `sql.js` version constant in `data-worker`
- document sql.js version link in README

## Testing
- `bun run lint` *(fails: Module needs an import attribute of type "json")*

------
https://chatgpt.com/codex/tasks/task_e_686fb386fb348329b11565a3dc973f27